### PR TITLE
use generated TS types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+.vscode

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_KEY } from '$env/static/public';
+import { type Database } from './db.types';
 
-export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_KEY);
+export const supabase = createClient<Database>(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_KEY);
 
 // const userStore = writable();
 
@@ -19,19 +20,7 @@ export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_KEY);
 
 export default {
 	trade: {
-		async write(
-			data: {
-				trade_date: string;
-				trade_id: string;
-				artist_name: string;
-				item_name: string;
-				quantity: number;
-				total_sales: number;
-				discount: number;
-				net_sales: number;
-				state: string;
-			}[]
-		) {
+		async write(data: Database['public']['Tables']['trade']['Insert']) {
 			const err = await supabase.from('trade').insert(data);
 			if (err !== null) {
 				console.log(err);

--- a/src/lib/db.types.ts
+++ b/src/lib/db.types.ts
@@ -1,0 +1,219 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      countries: {
+        Row: {
+          id: number
+          name: string
+        }
+        Insert: {
+          id?: number
+          name: string
+        }
+        Update: {
+          id?: number
+          name?: string
+        }
+        Relationships: []
+      }
+      trade: {
+        Row: {
+          artist_name: string | null
+          discount: number | null
+          id: number
+          item_name: string | null
+          net_sales: number | null
+          quantity: number | null
+          state: string | null
+          total_sales: number | null
+          trade_date: string | null
+          trade_id: string | null
+        }
+        Insert: {
+          artist_name?: string | null
+          discount?: number | null
+          id?: never
+          item_name?: string | null
+          net_sales?: number | null
+          quantity?: number | null
+          state?: string | null
+          total_sales?: number | null
+          trade_date?: string | null
+          trade_id?: string | null
+        }
+        Update: {
+          artist_name?: string | null
+          discount?: number | null
+          id?: never
+          item_name?: string | null
+          net_sales?: number | null
+          quantity?: number | null
+          state?: string | null
+          total_sales?: number | null
+          trade_date?: string | null
+          trade_id?: string | null
+        }
+        Relationships: []
+      }
+      trade_body: {
+        Row: {
+          artist_name: string | null
+          discount: number | null
+          id: number
+          item_name: string | null
+          net_sales: number | null
+          quantity: number | null
+          total_sales: number | null
+          trade_id: string | null
+        }
+        Insert: {
+          artist_name?: string | null
+          discount?: number | null
+          id?: never
+          item_name?: string | null
+          net_sales?: number | null
+          quantity?: number | null
+          total_sales?: number | null
+          trade_id?: string | null
+        }
+        Update: {
+          artist_name?: string | null
+          discount?: number | null
+          id?: never
+          item_name?: string | null
+          net_sales?: number | null
+          quantity?: number | null
+          total_sales?: number | null
+          trade_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "trade_body_trade_id_fkey"
+            columns: ["trade_id"]
+            isOneToOne: false
+            referencedRelation: "trade_head"
+            referencedColumns: ["trade_id"]
+          }
+        ]
+      }
+      trade_head: {
+        Row: {
+          state: string | null
+          trade_date: string | null
+          trade_id: string
+        }
+        Insert: {
+          state?: string | null
+          trade_date?: string | null
+          trade_id: string
+        }
+        Update: {
+          state?: string | null
+          trade_date?: string | null
+          trade_id?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
+      Database["public"]["Views"])
+  ? (Database["public"]["Tables"] &
+      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof Database["public"]["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
+  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
+  : never

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/src/routes/creator/[id]/+page.server.ts
+++ b/src/routes/creator/[id]/+page.server.ts
@@ -16,23 +16,7 @@ export const load: PageServerLoad = async ({ params }) => {
 		console.log(error);
 	}
 
-	const result = data as unknown as tradeUnit[];
 	return {
-		data: result ?? []
-	};
-};
-type tradeUnit = {
-	id: number;
-	trade_id: string;
-	artist_name: string;
-	item_name: string;
-	quantity: number;
-	total_sales: number;
-	discount: number;
-	net_sales: number;
-	trade_head: {
-		state: string;
-		trade_id: string;
-		trade_date: string;
+		data: data ?? []
 	};
 };

--- a/src/routes/importCsv/+page.server.ts
+++ b/src/routes/importCsv/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { supabase } from '$lib/db.js';
+import type { Database } from '$lib/db.types.js';
 
 const titleMap = new Map<string, number>([
 	['日期', 0],
@@ -61,20 +62,8 @@ export const actions = {
 		return true;
 	}
 };
-type TradeHead = {
-	trade_date: string;
-	trade_id: string;
-	state: string;
-};
-type TradeBody = {
-	artist_name: string;
-	item_name: string;
-	quantity: number;
-	trade_id: string;
-	total_sales: number;
-	discount: number;
-	net_sales: number;
-};
+type TradeHead = Database['public']['Tables']['trade_head']['Insert'];
+type TradeBody = Database['public']['Tables']['trade_body']['Insert'];
 
 const storeToDB = async (groupByIndex: Record<string, string[][]>) => {
 	let tradeBodyList: TradeBody[] = [];


### PR DESCRIPTION
because the original schema doesn't enforce `NOT NULL` this change introduces some unhandled `null` errors in the code